### PR TITLE
Use correct LITTLE_ENDIAN define

### DIFF
--- a/uip-conf.h
+++ b/uip-conf.h
@@ -200,7 +200,7 @@ User Configuration Options
  *
  * \hideinitializer
  */
-#define UIP_CONF_BYTE_ORDER      LITTLE_ENDIAN
+#define UIP_CONF_BYTE_ORDER      UIP_LITTLE_ENDIAN
 
 /**
  * Logging on or off


### PR DESCRIPTION
Fixes bug that octet 1+2 and 3+4 are flipped when building for STM32 with PlatformIO.